### PR TITLE
Add authentication for pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {BrowserRouter as Router, Routes, Route, Navigate} from "react-router-dom";
 import LoginPage from './components/LoginPage'
 import SignupPage from './components/SignupPage';
@@ -8,6 +8,21 @@ import SessionPage from './components/SessionPage';
 import {Box} from "@mui/material";
 
 function App() {
+
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) {
+            return parts.pop().split(';').shift()
+        };
+    }
+
+    function RequireAuth({ children }) {
+        let isAuth = getCookie('token') !==  undefined;
+
+        return isAuth === true ? children : <Navigate to="/login" replace />;
+    }
+
     return (
         <div className="App">
             <Box display={"flex"} flexDirection={"column"} padding={"1.5rem"}>
@@ -16,9 +31,21 @@ function App() {
                         <Route exact path="/" element={<Navigate replace to="/login" />}></Route>
                         <Route path="/login" element={<LoginPage/>}/>
                         <Route path="/signup" element={<SignupPage/>}/>
-                        <Route path='/matching' element={<MatchingPage/>}/>
-                        <Route path="/home" element={<HomePage/>}/>
-                        <Route path="/session" element={<SessionPage/>}/>
+                        <Route path='/matching' element={
+                            <RequireAuth>
+                                <MatchingPage/>
+                            </RequireAuth>
+                        }/>
+                        <Route path="/home" element={
+                            <RequireAuth>
+                                <HomePage/>
+                            </RequireAuth>
+                        }/>
+                        <Route path="/session" element={
+                            <RequireAuth>
+                                <SessionPage/>
+                            </RequireAuth>
+                        }/>
                     </Routes>
                 </Router>
             </Box>


### PR DESCRIPTION
Allows access to frontend pages only if the user's browser contains the JWT token created from a successful login previously. If at any point, the JWT token is deleted from the user's browser, it will redirect the user to the login page on the next page load/refresh.