### PR TITLE
Fix bug

### DIFF
--- a/frontend/src/components/PasswordChangePage.js
+++ b/frontend/src/components/PasswordChangePage.js
@@ -120,7 +120,8 @@ const PasswordChangePage = () => {
   const handlePasswordChange = async () => {
     setErrorMessage('');
     setSuccessfulReset(false);
-
+    closePasswordChangeDialog();
+    
     if (newPassword.length < 5) return setErrorMessage("Your password must be at least 5 characters long.")
     if (!passwordsMatch) return setErrorMessage("Your new password does not match. Please check again.");
     if (newPassword === currentPassword) return setErrorMessage("Your current password and new password cannot be the same!");
@@ -144,8 +145,6 @@ const PasswordChangePage = () => {
       clearInput();
       setSuccessfulReset(true);
     }
-    
-    closePasswordChangeDialog();
   }
 
   const passwordsMatch = newPassword === newConfirmPassword;


### PR DESCRIPTION
There was a bug where the dialog will remain open if the password change was not successful.

This was due to the `closePasswordChangeDialog` function being called only at the end of `handlePasswordChange`, but in cases of unsuccessful password changes, the function prematurely returns. Thus, the `closePasswordChangeDialog` function is not called, causing the dialog to remain open.

To solve the problem, I shifted the `closePasswordChangeDialog` function to the start of the `handlePasswordChange` function. Have verified it works locally.